### PR TITLE
Add cropped RGB image to product counting action

### DIFF
--- a/action/ProductCounting.action
+++ b/action/ProductCounting.action
@@ -1,6 +1,7 @@
 #Goal definition 
 
 sensor_msgs/CompressedImage cropped_depth_image
+sensor_msgs/CompressedImage cropped_rgb_image
 
 ---
 


### PR DESCRIPTION
Hi there,

Our new product counting system performs counting on RGB images. In order to support this and to maintain backwards-compatibility with the old product counting system, I suggest adding a cropped RGB image to the product counting action specification.